### PR TITLE
Roboversion: Ajustes

### DIFF
--- a/Roboversion/Functions/DevTools.ps1
+++ b/Roboversion/Functions/DevTools.ps1
@@ -1,12 +1,13 @@
-﻿. "../RoboVersion.ps1";
-. "../Functions/FileMap.ps1";
-. "../Functions/Functions.ps1";
-. "../Functions/FileManager.ps1";
-. "../Functions/UpdateVersioned.ps1";
-. "../Functions/UpdateRemoved.ps1";
-. "../Functions/UpdateToVersion.ps1";
-. "../Functions/UpdateToRemove.ps1";
-. "../Functions/Mirror.ps1";
+﻿. "./RoboVersion.ps1";
+. "./Functions/FileMap.ps1";
+. "./Functions/Functions.ps1";
+. "./Functions/FileManager.ps1";
+. "./Functions/UpdateVersioned.ps1";
+. "./Functions/UpdateRemoved.ps1";
+. "./Functions/UpdateToVersion.ps1";
+. "./Functions/UpdateToRemove.ps1";
+. "./Functions/Mirror.ps1";
+# . "./Functions/DevTools.ps1"; precisa ser executada na pasta onde fica "RoboVersion.ps1"!
 
 Function EchoFileMap($fileMap) {
 	If(-Not $fileMap) {
@@ -38,7 +39,7 @@ Function Test_GetFileMap() {
 		"C:\Folder\SubFolder\File.ext",
 		"";
 	$orderedMap = GetFileMap $filePathList;
-	# EchoFileMap $orderedMap;
+	EchoFileMap $orderedMap;
 	$sucess = TestFilePresence $orderedMap (
 		("C:\Folder\SubFolder\File.ext", 4, 7),
 		("C:\Folder\SubFolder\File.ext", 2, 5),

--- a/Roboversion/Functions/FileManager.ps1
+++ b/Roboversion/Functions/FileManager.ps1
@@ -8,7 +8,7 @@ Function DeleteFilesList($modifiedFilesMap, $filesToDelete, $listOnly) {
 		# Deleta arquivo
 		PrintText ("`tDeleted`t" + $fileToDelete.Path);
 		If(-Not $listOnly) {
-			$Null = Remove-Item -LiteralPath $fileToDelete.Path -Recurse -Force;
+			$Null = (Remove-Item -LiteralPath $fileToDelete.Path -Recurse -Force);
 		}
 		# Deleta no fileMap
 		$fileBasePath = (Split-Path -Path $fileToDelete.Path -Parent);
@@ -25,7 +25,7 @@ Function RenameRemovedFilesList($modifiedFilesMap, $filesToRename, $listOnly) {
 		Return;
 	}
 	# Da lista, renomeia arquivos
-	ForEach($fileToRename In $filesToRename | Sort-Object -Property NewRemotionCountdown) {
+	ForEach($fileToRename In ($filesToRename | Sort-Object -Property NewRemotionCountdown)) {
 		$newRemotionCountdown = $fileToRename.NewRemotionCountdown;
 		$fileToRename = $fileToRename.File;
 		# Renomeia arquivo
@@ -37,7 +37,7 @@ Function RenameRemovedFilesList($modifiedFilesMap, $filesToRename, $listOnly) {
 		$newName = ($fileToRename.BaseName + $version + $remotion + $fileToRename.Extension);
 		PrintText ("`tRenamed`t" + $fileToRename.Path + " ---> " + $newName);
 		If(-Not $listOnly) {
-			$Null = Rename-Item -LiteralPath $fileToRename.Path -NewName $newName -Force;
+			$Null = (Rename-Item -LiteralPath $fileToRename.Path -NewName $newName -Force);
 		}
 		# Renomeia no fileMap
 		$fileBasePath = (Split-Path -Path $fileToRename.Path -Parent);
@@ -57,7 +57,7 @@ Function RenameVersionedFilesList($modifiedFilesMap, $filesToRename, $listOnly) 
 		Return;
 	}
 	# Da lista, renomeia arquivos
-	ForEach($fileToRename In $filesToRename | Sort-Object -Property NewVersion) {
+	ForEach($fileToRename In ($filesToRename | Sort-Object -Property NewVersion)) {
 		$newVersion = $fileToRename.NewVersion;
 		$fileToRename = $fileToRename.File;
 		# Renomeia arquivo
@@ -69,7 +69,7 @@ Function RenameVersionedFilesList($modifiedFilesMap, $filesToRename, $listOnly) 
 		$newName = ($fileToRename.BaseName + $version + $remotion + $fileToRename.Extension);
 		PrintText ("`tRenamed`t" + $fileToRename.Path + " ---> " + $newName);
 		If(-Not $listOnly) {
-			$Null = Rename-Item -LiteralPath $fileToRename.Path -NewName $newName -Force;
+			$Null = (Rename-Item -LiteralPath $fileToRename.Path -NewName $newName -Force);
 		}
 		# Renomeia no fileMap
 		$fileBasePath = (Split-Path -Path $fileToRename.Path -Parent);
@@ -103,7 +103,7 @@ Function CopyVersionedFilesList($modifiedFilesMap, $filesToCopy, $listOnly) {
 		$newPath = (Join-Path -Path $fileBasePath -ChildPath $newName);
 		PrintText ("`tCopied`t" + $fileToCopy.Path + " ---> " + $newPath);
 		If(-Not $listOnly) {
-			$Null = Copy-Item -LiteralPath $fileToCopy.Path -Destination $newPath -Force;
+			$Null = (Copy-Item -LiteralPath $fileToCopy.Path -Destination $newPath -Force);
 		}
 		# Copia no fileMap
 		$nameKey = (Join-Path -Path $fileBasePath -ChildPath ($fileToCopy.BaseName + $fileToCopy.Extension));
@@ -141,11 +141,11 @@ Function CopyRemovedFilesList($modifiedFilesMap, $filesToCopy, $listOnly) {
 		PrintText ("`tCopied`t" + $fileToCopy.Path + " ---> " + $newPath);
 		If(-Not $listOnly) {
 			If($isFolder) {
-				$Null = Copy-Item -LiteralPath $fileToCopy.Path -Destination $newPath -Force;
+				$Null = (Copy-Item -LiteralPath $fileToCopy.Path -Destination $newPath -Force);
 				$Null = (Get-ChildItem -LiteralPath $fileToCopy.Path -Filter $wildcardOfRemovedFile | Move-Item -Destination $newPath -Force);
 				$Null = (Get-ChildItem -LiteralPath $fileToCopy.Path -Filter $wildcardOfRemovedFolder | Move-Item -Destination $newPath -Force);
 			} Else {
-				$Null = Copy-Item -LiteralPath $fileToCopy.Path -Destination $newPath -Force;
+				$Null = (Copy-Item -LiteralPath $fileToCopy.Path -Destination $newPath -Force);
 			}
 		}
 		# Copia no fileMap

--- a/Roboversion/RoboVersion.ps1
+++ b/Roboversion/RoboVersion.ps1
@@ -60,20 +60,24 @@ Function RoboVersion {
 			[Alias("L", "LO")]
 			[switch] $ListOnly = $False
 	)
-	. "./Functions/FileMap.ps1";
-	. "./Functions/Functions.ps1";
-	. "./Functions/FileManager.ps1";
-	. "./Functions/UpdateVersioned.ps1";
-	. "./Functions/UpdateRemoved.ps1";
-	. "./Functions/UpdateToVersion.ps1";
-	. "./Functions/UpdateToRemove.ps1";
-	. "./Functions/Mirror.ps1";
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\FileMap.ps1");
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\Functions.ps1");
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\FileManager.ps1");
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\UpdateVersioned.ps1");
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\UpdateRemoved.ps1");
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\UpdateToVersion.ps1");
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\UpdateToRemove.ps1");
+	. (Join-Path -Path $PSScriptRoot -ChildPath "\Functions\Mirror.ps1");
 	PrintText ("");
+	PrintText ("");
+	PrintText ("RoboVersion: " + $OrigPath + " ---> " + $DestPath);
 	PrintText ("");
 	# Lista os arquivos versionados e removidos
+	PrintText ("Escaneando por versionados e removidos...");
 	$modifiedLists = (GetModifiedFilesMap $DestPath $Threads);
 	$modifiedFilesMap = $modifiedLists.ModifiedFilesMap;
 	$removedFoldersList = $modifiedLists.RemovedFoldersList;
+	PrintText ("");
 	# Atualiza os arquivos versionados e removidos em $DestPath
 	PrintText ("Etapa 1: Tratar arquivos versionados no destino");
 	$modifiedFilesMap = (UpdateVersioned $modifiedFilesMap $VersionLimit $Destructive $ListOnly);
@@ -82,10 +86,12 @@ Function RoboVersion {
 	$modifiedFilesMap = (UpdateRemoved $modifiedFilesMap $removedFoldersList $RemotionCountdown $Destructive $ListOnly);
 	PrintText ("");
 	# Lista os arquivos a versionar ou remover
+	PrintText ("Escaneando por arquivos a serem modificados ou deletados...");
 	$willModifyLists = (GetWillModifyFilesMap $OrigPath $DestPath $Threads);
 	$toVersionList = $willModifyLists.WillModifyList;
 	$toRemoveList = $willModifyLists.WillDeleteList;
 	$toRemoveFolderList = $willModifyLists.WillDeleteFolderList;
+	PrintText ("");
 	# Atualiza os arquivos a versionar ou remover em $DestPath
 	PrintText ("Etapa 3: Criar versões de arquivos modificados na origem");
 	$modifiedFilesMap = (UpdateToVersion $modifiedFilesMap $toVersionList $VersionLimit $ListOnly);
@@ -96,5 +102,7 @@ Function RoboVersion {
 	PrintText ("Etapa 5: Iniciar Robocopy e realizar espelhamento");
 	# Realiza a cópia
 	Mirror $OrigPath $DestPath $Threads $ListOnly;
+	PrintText ("");
+	PrintText ("RoboVersion: Concluído");
 	PrintText ("");
 }


### PR DESCRIPTION
- (ALT) Formatação de código simples
- (FIX) 'RoboVersion': Call de outros arquivos em 'Functions' deve ser relativo a este, não ao script que o chamar
- (FIX) 'Functions': O LOG gerado pode não existir, se Robocopy não tiver nada a gravar
- (FIX) 'Functions': A lista de pastas removidas deve aceitar paths com mais de 260 carateres . Robocopy consegue listar todas as pastas, mas tudo deve ser filtrado para achar as removidas
- (UPD) 'RoboVersion': Antes de tudo, lista o path de origem e de destino
- (FIX) 'Functions': A procura de arquivos-a-modificar deve ser mais eficiente . Não há vantagem em ordenar tudo em um fileMap, basta colocar direto em uma lista!
- (UPD) 'RoboVersion': Antes de escanear arquivos, avisar