### PR TITLE
[FIX] 'Git': Push com amend sem titulo

### DIFF
--- a/Git/.gitconfig
+++ b/Git/.gitconfig
@@ -128,7 +128,7 @@
 		fi; \
 		\
 		if [[ -n $push ]]; then \
-			if [[ -n $titulo || -n $reamend ]]; then \
+			if [[ -n $titulo || -n $amend || -n $reamend ]]; then \
 				if [[ -n $amend || -n $reamend ]]; then \
 					echo \">> git push -f\"; \
 					git push -f; \


### PR DESCRIPTION
- (FIX) '.gitconfig': Se dado '--amend' com '--push', o '--push' não era executado